### PR TITLE
Fix #21 : patching unsupported methods breaks the whole patching process

### DIFF
--- a/Source/Shabby.cs
+++ b/Source/Shabby.cs
@@ -236,9 +236,12 @@ namespace Shabby
 				if (callSite == mInfo_ShaderFind_Replacement)
 					continue;
 
-				Log.Debug(
-					$"Patching call site : {callSite.DeclaringType.Assembly.GetName().Name}::{callSite.DeclaringType}.{callSite.Name}");
-				harmony.Patch(callSite, null, null, new HarmonyMethod(callSiteTranspiler));
+				try {
+					harmony.Patch(callSite, null, null, new HarmonyMethod(callSiteTranspiler));
+					Log.Debug($"Patching call site : {callSite.DeclaringType.Assembly.GetName().Name}::{callSite.DeclaringType}.{callSite.Name}");
+				} catch (Exception e) {
+					Log.Warning($"Failed to patch call site : {callSite.DeclaringType.Assembly.GetName().Name}::{callSite.DeclaringType}.{callSite.Name}\n{e.Message}\n{e.StackTrace}");
+				}
 			}
 		}
 


### PR DESCRIPTION
Try-catch the actual patching to prevent attempting to patch unsupported methods (ususally generics...) from breaking the whole patching process.